### PR TITLE
[#47] OpenAPI 통해 중간거리구현을 위한 지하철역 정보 데이터 바인딩 완료

### DIFF
--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -7,13 +7,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.TotalSubwayMasterResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
 import com.swyp.mema.domain.station.dto.response.subwayInfo.TotalStationResponse;
 import com.swyp.mema.domain.station.service.NearStationService;
+import com.swyp.mema.domain.station.service.StationMasterService;
 import com.swyp.mema.domain.station.service.StationService;
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class StationController {
 
 	private final StationService stationService;
 	private final NearStationService nearStationService;
+	private final StationMasterService stationMasterService;
 
 	/**
 	 * 모든 지하철역 조회 API
@@ -44,7 +46,7 @@ public class StationController {
 	/**
 	 * openAPI 통해 지하철역 조회 API
 	 */
-	@Hidden
+	// @Hidden
 	@Operation(summary = "모든 지하철역 조회 API", description = "OpenAPI 로 모든 지하철역 정보를 조회합니다.")
 	@GetMapping("/meets/{meetId}/station/all")
 	public ResponseEntity<Void> getAllStationByOpenAPI(
@@ -61,7 +63,7 @@ public class StationController {
 	 * 이 API 는 무시해주세요!
 	 * openAPI 통해 지하철역 시간표 조회 API
 	 */
-	@Hidden
+	// @Hidden
 	@Operation(summary = "해당 역에 대한 모든 시간표 조회 API", description = "OpenAPI 로 해당 '역 + 호선'에 대한 모든 시간표 정보를 조회합니다.",
 		security = {})
 	@GetMapping("/station/time")
@@ -79,7 +81,7 @@ public class StationController {
 	 * 이 API 는 무시해주세요!
 	 * 지하철 실시간 시간 데이터 가져오는 API
 	 */
-	@Hidden
+	// @Hidden
 	@Operation(summary = "지하철 실시간 시간 API 통해 앞뒤 역 탐색", description = "지하철 실시간 시간 OpenAPI 로 앞뒤 역 정보를 조회합니다.",
 		security = {})
 	@GetMapping("/near/station")
@@ -89,6 +91,21 @@ public class StationController {
 
 		String stationName = "왕십리";
 		TotalNearSubwayResponse response = nearStationService.getNearSubwayByAPI(stationName);
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 이 API 는 무시해주세요!
+	 * 지하철 실시간 시간 데이터 가져오는 API
+	 */
+	// @Hidden
+	@Operation(summary = "지하철 역사 마스터 API 통해 위도 & 경도 찾기", description = "지하철 역사 마스터 OpenAPI 로 해당 역의 위도 & 경도 값을 구합니다.",
+		security = {})
+	@GetMapping("/station/master")
+	public ResponseEntity<TotalSubwayMasterResponse> getStationMasterByOpenAPI(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		TotalSubwayMasterResponse response = stationMasterService.getSubwayMasterByAPI();
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
 import com.swyp.mema.domain.station.dto.response.subwayInfo.TotalStationResponse;
+import com.swyp.mema.domain.station.service.NearStationService;
 import com.swyp.mema.domain.station.service.StationService;
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class StationController {
 
 	private final StationService stationService;
+	private final NearStationService nearStationService;
 
 	/**
 	 * 모든 지하철역 조회 API
@@ -69,6 +72,23 @@ public class StationController {
 		String stationId = "MTRKRK1k210";	// 왕십리 수인분당선
 		String dailyTypeCode = "01";		// 01 : 평일, 02 : 토요일, 03 : 일요일
 		TotalSubwayTimeResponse response = stationService.getSubwayTimeByStationId(stationId, dailyTypeCode);
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 이 API 는 무시해주세요!
+	 * 지하철 실시간 시간 데이터 가져오는 API
+	 */
+	@Hidden
+	@Operation(summary = "지하철 실시간 시간 API 통해 앞뒤 역 탐색", description = "지하철 실시간 시간 OpenAPI 로 앞뒤 역 정보를 조회합니다.",
+		security = {})
+	@GetMapping("/near/station")
+	public ResponseEntity<TotalNearSubwayResponse> getNearStationTimeByOpenAPI(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+
+		String stationName = "왕십리";
+		TotalNearSubwayResponse response = nearStationService.getNearSubwayByAPI(stationName);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -15,6 +15,7 @@ import com.swyp.mema.domain.station.service.StationMasterService;
 import com.swyp.mema.domain.station.service.StationService;
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class StationController {
 	/**
 	 * openAPI 통해 지하철역 조회 API
 	 */
-	// @Hidden
+	@Hidden
 	@Operation(summary = "모든 지하철역 조회 API", description = "OpenAPI 로 모든 지하철역 정보를 조회합니다.")
 	@GetMapping("/meets/{meetId}/station/all")
 	public ResponseEntity<Void> getAllStationByOpenAPI(
@@ -63,7 +64,7 @@ public class StationController {
 	 * 이 API 는 무시해주세요!
 	 * openAPI 통해 지하철역 시간표 조회 API
 	 */
-	// @Hidden
+	@Hidden
 	@Operation(summary = "해당 역에 대한 모든 시간표 조회 API", description = "OpenAPI 로 해당 '역 + 호선'에 대한 모든 시간표 정보를 조회합니다.",
 		security = {})
 	@GetMapping("/station/time")
@@ -81,7 +82,7 @@ public class StationController {
 	 * 이 API 는 무시해주세요!
 	 * 지하철 실시간 시간 데이터 가져오는 API
 	 */
-	// @Hidden
+	@Hidden
 	@Operation(summary = "지하철 실시간 시간 API 통해 앞뒤 역 탐색", description = "지하철 실시간 시간 OpenAPI 로 앞뒤 역 정보를 조회합니다.",
 		security = {})
 	@GetMapping("/near/station")
@@ -98,7 +99,7 @@ public class StationController {
 	 * 이 API 는 무시해주세요!
 	 * 지하철 실시간 시간 데이터 가져오는 API
 	 */
-	// @Hidden
+	@Hidden
 	@Operation(summary = "지하철 역사 마스터 API 통해 위도 & 경도 찾기", description = "지하철 역사 마스터 OpenAPI 로 해당 역의 위도 & 경도 값을 구합니다.",
 		security = {})
 	@GetMapping("/station/master")

--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -6,7 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.swyp.mema.domain.station.dto.response.TotalStationResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.TotalStationResponse;
 import com.swyp.mema.domain.station.service.StationService;
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 
@@ -51,5 +52,23 @@ public class StationController {
 		Long userId = Long.parseLong(userDetails.getUsername());
 		stationService.getSubwayInfoByAPI(meetId, userId);
 		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * 이 API 는 무시해주세요!
+	 * openAPI 통해 지하철역 시간표 조회 API
+	 */
+	@Hidden
+	@Operation(summary = "해당 역에 대한 모든 시간표 조회 API", description = "OpenAPI 로 해당 '역 + 호선'에 대한 모든 시간표 정보를 조회합니다.",
+		security = {})
+	@GetMapping("/station/time")
+	public ResponseEntity<TotalSubwayTimeResponse> getAllStationTimeByOpenAPI(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+
+		String stationId = "MTRKRK1k210";	// 왕십리 수인분당선
+		String dailyTypeCode = "01";		// 01 : 평일, 02 : 토요일, 03 : 일요일
+		TotalSubwayTimeResponse response = stationService.getSubwayTimeByStationId(stationId, dailyTypeCode);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
+++ b/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
@@ -5,8 +5,11 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
-import com.swyp.mema.domain.station.dto.response.SingleStationResponse;
-import com.swyp.mema.domain.station.dto.response.TotalStationResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.SingleStationResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeBasicResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.TotalStationResponse;
 import com.swyp.mema.domain.station.model.Station;
 
 @Component
@@ -32,5 +35,24 @@ public class StationConverter {
 			.totalCount(totalCount)
 			.stationList(stationResponse)
 			.build();
+	}
+
+	public TotalSubwayTimeResponse toSubwayTimeListResponse(SubwayTimeBasicResponse basicResponse) {
+
+		List<SubwayTimeResponse> list = basicResponse.getResponse().getBody().getItems().getItemList().stream()
+			.map(res -> SubwayTimeResponse.builder()
+				.stationId(res.getStationId())
+				.stationName(res.getStationName())
+				.routeId(res.getRouteId())
+				.dailyTypeCode(res.getDailyTypeCode())
+				.departureTime(res.getDepartureTime())
+				.arrivalTime(res.getArrivalTime())
+				.endStationId(res.getEndStationId())
+				.endStationName(res.getEndStationName())
+				.upDownTypeCode(res.getUpDownTypeCode())
+				.build()
+			).toList();
+
+		return new TotalSubwayTimeResponse(list);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
+++ b/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
@@ -9,6 +9,9 @@ import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayBasicRespo
 import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayResponse;
 import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
 import com.swyp.mema.domain.station.dto.response.subwayInfo.SingleStationResponse;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.SubwayMasterBasicResponse;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.SubwayMasterResponse;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.TotalSubwayMasterResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeBasicResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeResponse;
@@ -90,5 +93,19 @@ public class StationConverter {
 
 		// TotalNearSubwayResponse에 변환된 리스트를 설정
 		return new TotalNearSubwayResponse(responses);
+	}
+
+	public TotalSubwayMasterResponse toSubwayMasterBasicResponse(SubwayMasterBasicResponse basicResponse) {
+
+		List<SubwayMasterResponse> responses = basicResponse.getSubwayStationMaster().getRows().stream()
+			.map(res -> SubwayMasterResponse.builder()
+				.stationName(res.getBuildingName())
+				.route(res.getRoute())
+				.lat(res.getLatitude())
+				.lot(res.getLongitude())
+				.build()
+			).toList();
+
+		return new TotalSubwayMasterResponse(responses);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
+++ b/src/main/java/com/swyp/mema/domain/station/converter/StationConverter.java
@@ -5,6 +5,9 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayBasicResponse;
+import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayResponse;
+import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
 import com.swyp.mema.domain.station.dto.response.subwayInfo.SingleStationResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeBasicResponse;
 import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
@@ -54,5 +57,38 @@ public class StationConverter {
 			).toList();
 
 		return new TotalSubwayTimeResponse(list);
+	}
+
+	public TotalNearSubwayResponse toNearSubwayBasicResponse(NearSubwayBasicResponse basicResponse) {
+
+		// Stream을 통해 realtimeArrivalList를 NearSubwayResponse로 변환
+		List<NearSubwayResponse> responses = basicResponse.getRealtimeArrivalList().stream()
+			.map(res -> NearSubwayResponse.builder()
+				.rowNum(res.getRowNum())                        // 순서
+				.subwayHeading(res.getSubwayHeading())          // 지하철호선ID
+				.statnFid(res.getStatnFid())                    // 이전 지하철역 ID
+				.statnTid(res.getStatnTid())                    // 다음 지하철역 ID
+				.statnId(res.getStatnId())                      // 지하철역 ID
+				.statnNm(res.getStatnNm())                      // 지하철역명
+				.trnsitCo(res.getTrnsitCo())                    // 환승노선수
+				.ordkey(res.getOrdkey())                        // 도착예정열차순번
+				.subwayList(res.getSubwayList())                // 연계호선ID
+				.statnList(res.getStatnList())                  // 연계지하철역ID
+				.btrainSttus(res.getBtrainSttus())              // 열차종류
+				.barvlDt(res.getBarvlDt())                      // 열차도착 예정시간
+				.btrainNo(res.getBtrainNo())                    // 열차번호
+				.bstatnId(res.getBstatnId())                    // 종착 지하철역ID
+				.bstatnNm(res.getBstatnNm())                    // 종착 지하철역명
+				.recptnDt(res.getRecptnDt())                    // 열차도착정보 생성 시각
+				.arvlMsg2(res.getArvlMsg2())                    // 첫번째 도착메시지
+				.arvlMsg3(res.getArvlMsg3())                    // 두번째 도착메시지
+				.arvlCd(res.getArvlCd())                        // 도착코드
+				.lstcarAt(res.getLstcarAt())                    // 막차 여부
+				.build()
+			)
+			.toList(); // 결과를 리스트로 변환
+
+		// TotalNearSubwayResponse에 변환된 리스트를 설정
+		return new TotalNearSubwayResponse(responses);
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/NearSubwayBasicResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/NearSubwayBasicResponse.java
@@ -1,0 +1,136 @@
+package com.swyp.mema.domain.station.dto.response.nearSubway;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class NearSubwayBasicResponse {
+
+	@JsonProperty("errorMessage")
+	private ErrorMessage errorMessage;
+
+	@JsonProperty("realtimeArrivalList")
+	private List<RealtimeArrival> realtimeArrivalList;
+
+	@Data
+	public static class ErrorMessage {
+
+		@JsonProperty("status")
+		private int status;
+
+		@JsonProperty("code")
+		private String code;
+
+		@JsonProperty("message")
+		private String message;
+
+		@JsonProperty("link")
+		private String link;
+
+		@JsonProperty("developerMessage")
+		private String developerMessage;
+
+		@JsonProperty("total")
+		private int total;
+	}
+
+	@Data
+	public static class RealtimeArrival {
+
+		@JsonProperty("beginRow")
+		private String beginRow;
+
+		@JsonProperty("endRow")
+		private String endRow;
+
+		@JsonProperty("curPage")
+		private String curPage;
+
+		@JsonProperty("pageRow")
+		private String pageRow;
+
+		@JsonProperty("totalCount")
+		private int totalCount;
+
+		@JsonProperty("rowNum")
+		private int rowNum;
+
+		@JsonProperty("selectedCount")
+		private int selectedCount;
+
+		@JsonProperty("subwayId")
+		private String subwayId;
+
+		@JsonProperty("subwayNm")
+		private String subwayNm;
+
+		@JsonProperty("updnLine")
+		private String updnLine;
+
+		@JsonProperty("trainLineNm")
+		private String trainLineNm;
+
+		@JsonProperty("subwayHeading")
+		private String subwayHeading;
+
+		@JsonProperty("statnFid")
+		private String statnFid;
+
+		@JsonProperty("statnTid")
+		private String statnTid;
+
+		@JsonProperty("statnId")
+		private String statnId;
+
+		@JsonProperty("statnNm")
+		private String statnNm;
+
+		@JsonProperty("trainCo")
+		private String trainCo;
+
+		@JsonProperty("trnsitCo")
+		private String trnsitCo;
+
+		@JsonProperty("ordkey")
+		private String ordkey;
+
+		@JsonProperty("subwayList")
+		private String subwayList;
+
+		@JsonProperty("statnList")
+		private String statnList;
+
+		@JsonProperty("btrainSttus")
+		private String btrainSttus;
+
+		@JsonProperty("barvlDt")
+		private String barvlDt;
+
+		@JsonProperty("btrainNo")
+		private String btrainNo;
+
+		@JsonProperty("bstatnId")
+		private String bstatnId;
+
+		@JsonProperty("bstatnNm")
+		private String bstatnNm;
+
+		@JsonProperty("recptnDt")
+		private String recptnDt;
+
+		@JsonProperty("arvlMsg2")
+		private String arvlMsg2;
+
+		@JsonProperty("arvlMsg3")
+		private String arvlMsg3;
+
+		@JsonProperty("arvlCd")
+		private String arvlCd;
+
+		@JsonProperty("lstcarAt")
+		private String lstcarAt;
+	}
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/NearSubwayResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/NearSubwayResponse.java
@@ -1,0 +1,86 @@
+package com.swyp.mema.domain.station.dto.response.nearSubway;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NearSubwayResponse {
+
+	// 순서
+	private int rowNum;
+
+	/**
+	 * 지하철호선ID
+	 *  (1001:1호선, 1002:2호선, 1003:3호선, 1004:4호선, 1005:5호선 1006:6호선, 1007:7호선, 1008:8호선, 1009:9호선,
+	 *  1061:중앙선1063:경의중앙선, 1065:공항철도, 1067:경춘선, 1075:수의분당선 1077:신분당선, 1092:우이신설선, 1093:서해선, 1081:경강선, 1032:GTX-A)
+	 */
+	private String subwayHeading;
+
+	// 이전 지하철역 ID
+	private String statnFid;
+
+	// 다음 지하철역ID
+	private String statnTid;
+
+	// 지하철역ID
+	private String statnId;
+
+	// 지하철역명
+	private String statnNm;
+
+	// 환승노선수
+	private String trnsitCo;
+
+	/**
+	 * 도착예정열차순번
+	 * (상하행코드(1자리), 순번(첫번째, 두번째 열차 , 1자리), 첫번째 도착예정 정류장 - 현재 정류장(3자리), 목적지 정류장, 급행여부(1자리))
+	 * Ex. 왕십리 => 01000방화0
+	 */
+	private String ordkey;
+
+	/**
+	 * 연계호선ID (1002, 1007 등 연계대상 호선ID)
+	 */
+	private String subwayList;
+
+	/**
+	 * 연계지하철역ID (1002000233, 1007000000)
+	 */
+	private String statnList;
+
+	/**
+	 * 열차종류 (급행,ITX,일반,특급)
+	 */
+	private String btrainSttus;
+
+	// 열차도착 예정시간 (단위:초)
+	private String barvlDt;
+
+	// 열차번호 (현재운행하고 있는 호선별 열차번호)
+	private String btrainNo;
+
+	// 종착 지하철역ID
+	private String bstatnId;
+
+	// 종착 지하철역명
+	private String bstatnNm;
+
+	// 열차도착정보를 생성한 시각
+	private String recptnDt;
+
+	// 첫번째도착메세지 (도착, 출발 , 진입 등)
+	private String arvlMsg2;
+
+	// 두번째도착메세지 (종합운동장 도착, 12분 후 (광명사거리) 등)
+	private String arvlMsg3;
+
+	/**
+	 * 도착코드
+	 * (0:진입, 1:도착, 2:출발, 3:전역출발, 4:전역진입, 5:전역도착, 99:운행중)
+	 */
+	private String arvlCd;
+
+	// 막차 여부 (1:막차, 0:아님)
+	private String lstcarAt;
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/TotalNearSubwayResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/nearSubway/TotalNearSubwayResponse.java
@@ -1,0 +1,13 @@
+package com.swyp.mema.domain.station.dto.response.nearSubway;
+
+import java.util.List;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TotalNearSubwayResponse {
+	List<NearSubwayResponse> subwayTimeList;
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/SingleStationResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/SingleStationResponse.java
@@ -1,4 +1,4 @@
-package com.swyp.mema.domain.station.dto.response;
+package com.swyp.mema.domain.station.dto.response.subwayInfo;
 
 import lombok.Getter;
 

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/SubwayInfoBasicResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/SubwayInfoBasicResponse.java
@@ -1,0 +1,68 @@
+package com.swyp.mema.domain.station.dto.response.subwayInfo;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class SubwayInfoBasicResponse {
+
+	@JsonProperty("response")
+	private Response response;
+
+	@Data
+	public static class Response {
+
+		@JsonProperty("header")
+		private Header header;
+
+		@JsonProperty("body")
+		private Body body;
+	}
+
+	@Data
+	public static class Header {
+
+		@JsonProperty("resultCode")
+		private String resultCode;
+
+		@JsonProperty("resultMsg")
+		private String resultMsg;
+	}
+
+	@Data
+	public static class Body {
+
+		@JsonProperty("items")
+		private Items items;
+
+		@JsonProperty("pageNo")
+		private int pageNo;
+		@JsonProperty("numOfRows")
+		private int numOfRows;
+		@JsonProperty("totalCount")
+		private int totalCount;
+	}
+
+	@Data
+	public static class Items {
+
+		@JsonProperty("item")
+		private List<Item> itemList;
+	}
+
+	@Data
+	public static class Item {
+
+		@JsonProperty("subwayStationId")
+		private String stationId;
+
+		@JsonProperty("subwayStationName")
+		private String stationName;
+
+		@JsonProperty("subwayRouteName")
+		private String routeName;
+	}
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/TotalStationResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayInfo/TotalStationResponse.java
@@ -1,4 +1,4 @@
-package com.swyp.mema.domain.station.dto.response;
+package com.swyp.mema.domain.station.dto.response.subwayInfo;
 
 import java.util.List;
 

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/SubwayMasterBasicResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/SubwayMasterBasicResponse.java
@@ -1,0 +1,56 @@
+package com.swyp.mema.domain.station.dto.response.subwayMaster;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class SubwayMasterBasicResponse {
+
+	@JsonProperty("subwayStationMaster")
+	private SubwayStationMaster subwayStationMaster;
+
+	@Data
+	public static class SubwayStationMaster {
+
+		@JsonProperty("list_total_count")
+		private int listTotalCount;
+
+		@JsonProperty("RESULT")
+		private Result result;
+
+		@JsonProperty("row")
+		private List<Row> rows;
+	}
+
+	@Data
+	public static class Result {
+
+		@JsonProperty("CODE")
+		private String code;
+
+		@JsonProperty("MESSAGE")
+		private String message;
+	}
+
+	@Data
+	public static class Row {
+
+		@JsonProperty("BLDN_ID")
+		private String buildingId;
+
+		@JsonProperty("BLDN_NM")
+		private String buildingName;
+
+		@JsonProperty("ROUTE")
+		private String route;
+
+		@JsonProperty("LAT")
+		private String latitude;
+
+		@JsonProperty("LOT")
+		private String longitude;
+	}
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/SubwayMasterResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/SubwayMasterResponse.java
@@ -1,0 +1,22 @@
+package com.swyp.mema.domain.station.dto.response.subwayMaster;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubwayMasterResponse {
+
+	// 역사명
+	private String stationName;
+
+	// 호선
+	private String route;
+
+	// 위도
+	private String lat;
+
+	// 경도
+	private String lot;
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/TotalSubwayMasterResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayMaster/TotalSubwayMasterResponse.java
@@ -1,0 +1,14 @@
+package com.swyp.mema.domain.station.dto.response.subwayMaster;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TotalSubwayMasterResponse {
+
+	private List<SubwayMasterResponse> masterList;
+
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/SubwayTimeBasicResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/SubwayTimeBasicResponse.java
@@ -1,5 +1,6 @@
-package com.swyp.mema.domain.station.dto.response;
+package com.swyp.mema.domain.station.dto.response.subwayTime;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,7 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
-public class OpenApiBasicResponse {
+
+public class SubwayTimeBasicResponse {
 
 	@JsonProperty("response")
 	private Response response;
@@ -36,7 +38,7 @@ public class OpenApiBasicResponse {
 	public static class Body {
 
 		@JsonProperty("items")
-		private Items items;
+		private Items items = new Items(); // 기본값으로 빈 객체 초기화
 
 		@JsonProperty("pageNo")
 		private int pageNo;
@@ -50,19 +52,37 @@ public class OpenApiBasicResponse {
 	public static class Items {
 
 		@JsonProperty("item")
-		private List<Item> itemList;
+		private List<Item> itemList = new ArrayList<>(); // 기본값으로 빈 리스트 초기화;
 	}
 
 	@Data
 	public static class Item {
 
+		@JsonProperty("arrTime")
+		private String arrivalTime;
+
+		@JsonProperty("dailyTypeCode")
+		private String dailyTypeCode;
+
+		@JsonProperty("depTime")
+		private String departureTime;
+
+		@JsonProperty("endSubwayStationId")
+		private String endStationId;
+
+		@JsonProperty("endSubwayStationNm")
+		private String endStationName;
+
+		@JsonProperty("subwayRouteId")
+		private String routeId;
+
 		@JsonProperty("subwayStationId")
 		private String stationId;
 
-		@JsonProperty("subwayStationName")
+		@JsonProperty("subwayStationNm")
 		private String stationName;
 
-		@JsonProperty("subwayRouteName")
-		private String routeName;
+		@JsonProperty("upDownTypeCode")
+		private String upDownTypeCode;
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/SubwayTimeResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/SubwayTimeResponse.java
@@ -1,0 +1,37 @@
+package com.swyp.mema.domain.station.dto.response.subwayTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubwayTimeResponse {
+
+	// 지하철역 ID
+	private String stationId;
+
+	// 지하철역명
+	private String stationName;
+
+	// 지하철 노선 ID
+	private String routeId;
+
+	// 요일 구분 코드 (01: 평일, 02: 토요일, 03: 일요일)
+	private String dailyTypeCode;
+
+	// 출발 시간
+	private String departureTime;
+
+	// 도착 시간
+	private String arrivalTime;
+
+	// 종점 지하철역 ID
+	private String endStationId;
+
+	// 종점 지하철역명
+	private String endStationName;
+
+	// 상하행 구분 코드 (U: 상행, D: 하행)
+	private String upDownTypeCode;
+
+}

--- a/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/TotalSubwayTimeResponse.java
+++ b/src/main/java/com/swyp/mema/domain/station/dto/response/subwayTime/TotalSubwayTimeResponse.java
@@ -1,0 +1,12 @@
+package com.swyp.mema.domain.station.dto.response.subwayTime;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TotalSubwayTimeResponse {
+	List<SubwayTimeResponse> subwayTimeList;
+}

--- a/src/main/java/com/swyp/mema/domain/station/model/Station.java
+++ b/src/main/java/com/swyp/mema/domain/station/model/Station.java
@@ -30,6 +30,10 @@ public class Station extends BaseEntity { // + 위/경도
 
 	private int toNext;			// 다음역까지 소요시간
 
+	private double latitude;	// 위도
+
+	private double longitude;	// 경도
+
 	@Builder
 	public Station(String stationId, String stationName, String routeName) {
 		this.stationId = stationId;

--- a/src/main/java/com/swyp/mema/domain/station/model/Station.java
+++ b/src/main/java/com/swyp/mema/domain/station/model/Station.java
@@ -30,9 +30,9 @@ public class Station extends BaseEntity { // + 위/경도
 
 	private int toNext;			// 다음역까지 소요시간
 
-	private double latitude;	// 위도
+	private double lat;	// 위도
 
-	private double longitude;	// 경도
+	private double lot;	// 경도
 
 	@Builder
 	public Station(String stationId, String stationName, String routeName) {

--- a/src/main/java/com/swyp/mema/domain/station/service/NearStationService.java
+++ b/src/main/java/com/swyp/mema/domain/station/service/NearStationService.java
@@ -1,0 +1,76 @@
+package com.swyp.mema.domain.station.service;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.swyp.mema.domain.station.converter.StationConverter;
+import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayBasicResponse;
+import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class NearStationService {
+
+	private static final String BASE_URL = "http://swopenAPI.seoul.go.kr/api/subway";
+	private static final String NEAR_SUBWAY_SERVICE_NAME = "realtimeStationArrival";
+	private static final String TYPE = "json";
+
+	private static final String START_INDEX = "1";
+	private static final String END_INDEX = "100";
+
+	private final WebClient webClient;
+	private final StationConverter converter;
+
+	@Value("${api.time.key}")
+	private String serviceKey;    // 디코딩된 API 서비스 키
+
+	public NearStationService(WebClient.Builder webClientBuilder, StationConverter converter) {
+		this.webClient = webClientBuilder.baseUrl(BASE_URL).build(); // 기본 URL 설정
+		this.converter = converter;
+	}
+
+	/*
+	 * 지하철 실시간 시간 데이터 OpenAPI 를 호출하여 현재역 기준 앞뒤 역 데이터를 가져오기
+	 */
+	@Transactional
+	public TotalNearSubwayResponse getNearSubwayByAPI(String stationName) {
+
+		// 서울역인 경우 서울로 변경
+		stationName = stationName.equals("서울역") ? "서울" : stationName;
+
+		// URI 빌더로 URL 생성
+		URI uri = createNearSubwayUri(stationName);
+		log.info("Generated SubwayInfo API Request URL: {}", uri);
+
+		// OpenAPI 요청 및 JSON 확인
+		NearSubwayBasicResponse result = fetchOpenApiForNearSubway(uri);
+		log.info("result : {}", result);
+		return converter.toNearSubwayBasicResponse(result);
+	}
+
+	private URI createNearSubwayUri(String stationName) {
+
+		return UriComponentsBuilder.fromHttpUrl(BASE_URL)
+			.pathSegment(serviceKey, TYPE, NEAR_SUBWAY_SERVICE_NAME, START_INDEX, END_INDEX, stationName)
+			.encode() // 자동 인코딩 (한글은 인코딩되지 않음)
+			.build()
+			.toUri();
+	}
+
+	private NearSubwayBasicResponse fetchOpenApiForNearSubway(URI uri) {
+
+		// WebClient 요청
+		return webClient.get()
+			.uri(uri) // 생성한 URI를 그대로 사용
+			.retrieve() // 응답 수신
+			.bodyToMono(NearSubwayBasicResponse.class)
+			.block(); // 동기 방식으로 결과 받기
+	}
+}

--- a/src/main/java/com/swyp/mema/domain/station/service/StationMasterService.java
+++ b/src/main/java/com/swyp/mema/domain/station/service/StationMasterService.java
@@ -1,0 +1,72 @@
+package com.swyp.mema.domain.station.service;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.swyp.mema.domain.station.converter.StationConverter;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.SubwayMasterBasicResponse;
+import com.swyp.mema.domain.station.dto.response.subwayMaster.TotalSubwayMasterResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class StationMasterService {
+
+	private static final String BASE_URL = "http://openapi.seoul.go.kr:8088";
+	private static final String SUBWAY_MASTER_SERVICE_NAME = "subwayStationMaster";
+	private static final String TYPE = "json";
+
+	private static final String START_INDEX = "1";
+	private static final String END_INDEX = "800";
+
+	private final WebClient webClient;
+	private final StationConverter converter;
+
+	@Value("${api.master.key}")
+	private String serviceKey;    // 디코딩된 API 서비스 키
+
+	public StationMasterService(WebClient.Builder webClientBuilder, StationConverter converter) {
+		this.webClient = webClientBuilder.baseUrl(BASE_URL).build(); // 기본 URL 설정
+		this.converter = converter;
+	}
+
+	/*
+	 * 지하철 역사 마스터 (위도 & 경도) 데이터 가져오는 메서드
+	 */
+	@Transactional
+	public TotalSubwayMasterResponse getSubwayMasterByAPI() {
+
+		// URI 빌더로 URL 생성
+		URI uri = createSubwayMasterUri();
+		log.info("Generated SubwayInfo API Request URL: {}", uri);
+
+		// OpenAPI 요청 및 JSON 확인
+		SubwayMasterBasicResponse result = fetchOpenApiForSubwayMaster(uri);
+		log.info("result : {}", result);
+		return converter.toSubwayMasterBasicResponse(result);
+	}
+
+	private URI createSubwayMasterUri() {
+
+		return UriComponentsBuilder.fromHttpUrl(BASE_URL)
+			.pathSegment(serviceKey, TYPE, SUBWAY_MASTER_SERVICE_NAME, START_INDEX, END_INDEX)
+			.build()
+			.toUri();
+	}
+
+	private SubwayMasterBasicResponse fetchOpenApiForSubwayMaster(URI uri) {
+
+		// WebClient 요청
+		return webClient.get()
+			.uri(uri) // 생성한 URI를 그대로 사용
+			.retrieve() // 응답 수신
+			.bodyToMono(SubwayMasterBasicResponse.class)
+			.block(); // 동기 방식으로 결과 받기
+	}
+}

--- a/src/main/java/com/swyp/mema/domain/station/service/StationService.java
+++ b/src/main/java/com/swyp/mema/domain/station/service/StationService.java
@@ -10,8 +10,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.swyp.mema.domain.station.converter.StationConverter;
-import com.swyp.mema.domain.station.dto.response.OpenApiBasicResponse;
-import com.swyp.mema.domain.station.dto.response.TotalStationResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.SubwayInfoBasicResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.SubwayTimeBasicResponse;
+import com.swyp.mema.domain.station.dto.response.subwayTime.TotalSubwayTimeResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.TotalStationResponse;
 import com.swyp.mema.domain.station.model.Station;
 import com.swyp.mema.domain.station.repository.StationRepository;
 import com.swyp.mema.domain.meet.exception.MeetNotFoundException;
@@ -32,7 +34,8 @@ import lombok.extern.slf4j.Slf4j;
 public class StationService {
 
 	private static final String BASE_URL = "http://apis.data.go.kr/1613000/SubwayInfoService";
-	private static final String SERVICE_NAME = "getKwrdFndSubwaySttnList";
+	private static final String SUBWAY_INFO_SERVICE_NAME = "getKwrdFndSubwaySttnList";
+	private static final String SUBWAY_TIME_SERVICE_NAME = "getSubwaySttnAcctoSchdulList";
 	private static final String TYPE = "json";
 
 
@@ -76,8 +79,7 @@ public class StationService {
 
 		return converter.toTotalStationResponse(all);
 	}
-
-
+	
 	/*
 	 * OpenAPI 를 호출하여 Station 값 변경
 	 */
@@ -91,11 +93,11 @@ public class StationService {
 		validateMeetMember(meetMember.getId());
 
 		// URI 빌더로 URL 생성
-		URI uri = createUri();
-		log.info("Generated URL: {}", uri);
+		URI uri = createSubwayInfoUri();
+		log.info("Generated SubwayInfo API Request URL: {}", uri);
 
 		// OpenAPI 요청 및 JSON 확인
-		OpenApiBasicResponse result = fetchSubwayInfoFromOpenApi(uri);
+		SubwayInfoBasicResponse result = fetchOpenApiForSubwayInfo(uri);
 		log.info("result : {}", result);
 
 
@@ -111,27 +113,78 @@ public class StationService {
 
 	}
 
-	private OpenApiBasicResponse fetchSubwayInfoFromOpenApi(URI uri) {
+	/*
+	 * 해당 역ID(역이름 + 호선 정보) 통해 해당 호선에 대한 모든 시간 데이터 요청 OpenAPI
+	 * */
+	@Transactional
+	public TotalSubwayTimeResponse getSubwayTimeByStationId(String stationId, String dailyTypeCode) {
+
+		// 필수 검증 로직
+		// User user = validateUser(userId);
+		// Meet meet = validateMeet(meetId);
+		// MeetMember meetMember = validateMeetMember(user, meet);
+		// validateMeetMember(meetMember.getId());
+
+		// URI 빌더로 URL 생성
+		System.out.println("serviceKey = " + serviceKey);
+		URI uri = createSubwayTimeUri(stationId, dailyTypeCode);
+		log.info("Generated SubwayTime API Request URL: {}", uri);
+
+		// OpenAPI 요청 및 JSON 확인
+		SubwayTimeBasicResponse result = fetchOpenApiForSubwayTime(uri);
+		log.info("result : {}", result);
+
+		return converter.toSubwayTimeListResponse(result);
+	}
+
+	private SubwayTimeBasicResponse fetchOpenApiForSubwayTime(URI uri) {
 
 		// WebClient 요청
 		return webClient.get()
 			.uri(uri) // 생성한 URI를 그대로 사용
 			.retrieve() // 응답 수신
-			.bodyToMono(OpenApiBasicResponse.class)
+			.bodyToMono(SubwayTimeBasicResponse.class)
 			.block(); // 동기 방식으로 결과 받기
 	}
 
-	private URI createUri() {
+	private SubwayInfoBasicResponse fetchOpenApiForSubwayInfo(URI uri) {
+
+		// WebClient 요청
+		return webClient.get()
+			.uri(uri) // 생성한 URI를 그대로 사용
+			.retrieve() // 응답 수신
+			.bodyToMono(SubwayInfoBasicResponse.class)
+			.block(); // 동기 방식으로 결과 받기
+	}
+
+	private URI createSubwayInfoUri() {
 
 		// URI 빌더로 URL 생성
 		return UriComponentsBuilder.fromHttpUrl(BASE_URL)
-			.pathSegment(SERVICE_NAME)
+			.pathSegment(SUBWAY_INFO_SERVICE_NAME)
 			.queryParam("serviceKey", serviceKey) // 자동으로 인코딩
 			.queryParam("_type", TYPE) // 반환 타입
-			// .queryParam("numOfRows", END_INDEX) // 최대 행 수
+			.queryParam("numOfRows", 1200) // 최대 행 수
 			// .queryParam("pageNo", START_INDEX) // 시작 페이지
 			.build()
 			.toUri();
+	}
+
+	private URI createSubwayTimeUri(String stationId, String dailyTypeCode) {
+
+		// URI 빌더로 URL 생성
+		return UriComponentsBuilder.fromHttpUrl(BASE_URL)
+			.pathSegment(SUBWAY_TIME_SERVICE_NAME)
+			.queryParam("serviceKey", serviceKey) // 자동으로 인코딩
+			.queryParam("subwayStationId", stationId)
+			.queryParam("dailyTypeCode", dailyTypeCode)
+			.queryParam("_type", TYPE) // 반환 타입
+			.queryParam("upDownTypeCode", "U")	// U : 상행, D : 하행
+			.queryParam("numOfRows", 500) // 최대 행 수
+			// .queryParam("pageNo", 0) // 시작 페이지
+			.build()
+			.toUri();
+
 	}
 
 	private MeetMember validateMeetMember(User user, Meet meet) {

--- a/src/main/java/com/swyp/mema/domain/station/service/StationService.java
+++ b/src/main/java/com/swyp/mema/domain/station/service/StationService.java
@@ -47,7 +47,7 @@ public class StationService {
 	private final StationConverter converter;
 	private final StationRepository stationRepository;
 
-	@Value("${api.key}")
+	@Value("${api.info.key}")
 	private String serviceKey;    // 디코딩된 API 서비스 키
 
 	public StationService(WebClient.Builder webClientBuilder, StationConverter converter,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,4 +12,9 @@ springdoc:
     path: /swagger-ui.html
 
 api:
-  key: ${API_KEY}
+  info:
+    key: ${API_INFO_KEY}
+  time:
+    key: ${API_TIME_KEY}
+  master:
+    key: ${API_MASTER_KEY}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목`으로 작성해주세요. (ex) [#1] 프로젝트 초기 설정 작업 -->

### 🧑‍💻 작업 내용
- .env 파일 API_TIME_KEY, API_MASTER_KEY 추가완료했습니다.
- 지하철 정보, 지하철 시간표, 지하철 앞뒤역 정보, 지하철 위도 & 경도 API 연결

### ✨ 리뷰 포인트
- 모든 데이터는 `TotalXXResponse` 로 보시면 됩니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #47
