### PR TITLE
[#65] 역 DB 중복 이슈 & Chat GPT 호출 시점 변경 및 중간 지점 값이 변경되는 이슈 해결

### DIFF
--- a/src/main/java/com/swyp/mema/domain/meet/converter/MeetConverter.java
+++ b/src/main/java/com/swyp/mema/domain/meet/converter/MeetConverter.java
@@ -43,6 +43,9 @@ public class MeetConverter {
 			.meetState(meet.getState())
 			.meetDate(meet.getMeetDate())
 			.meetLocation(meet.getMeetLocation())
+			.routeName(meet.getLine())
+			.lat(meet.getLat())
+			.lot(meet.getLot())
 			.voteExpiredDate(meet.getExpiredVoteDate())
 			.members(members)
 			.build();

--- a/src/main/java/com/swyp/mema/domain/meet/dto/response/SingleMeetRes.java
+++ b/src/main/java/com/swyp/mema/domain/meet/dto/response/SingleMeetRes.java
@@ -32,8 +32,17 @@ public class SingleMeetRes {
 	@Schema(description = "약속 날짜", example = "2025-01-10")
 	private LocalDate meetDate;
 
-	@Schema(description = "약속 장소", example = "서울역")
+	@Schema(description = "만나는 역 이름", example = "서울역")
 	private String meetLocation;
+
+	@Schema(description = "만나는 역 호선", example = "1호선")
+	private String routeName;
+
+	@Schema(description = "만나는 역 위도", example = "37.556228")
+	private String lat;
+
+	@Schema(description = "만나는 역 경도", example = "126.972135")
+	private String lot;
 
 	@Schema(description = "날짜 투표 만료일", example = "2025-01-01T02:11:00")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")	// 직렬화

--- a/src/main/java/com/swyp/mema/domain/meet/model/Meet.java
+++ b/src/main/java/com/swyp/mema/domain/meet/model/Meet.java
@@ -48,8 +48,12 @@ public class Meet extends BaseEntity {
 	private State state;
 
 	private LocalDate meetDate;
-	private String meetLocation;
 	private LocalDateTime expiredVoteDate;
+
+	private String meetLocation;	// 만나는 역 이름
+	private String line;			// 만나는 역 호선
+	private String lat;				// 만나는 역 위도
+	private String lot;				// 만나는 역 경도
 
 	@OneToMany(mappedBy = "meet", cascade = CascadeType.REMOVE, orphanRemoval = true)
 	private List<MeetMember> members = new ArrayList<>();
@@ -91,7 +95,10 @@ public class Meet extends BaseEntity {
 
 	public void setMeetDate(LocalDate dateTime) {this.meetDate = dateTime; }
 
-	public void setMeetLocation(String meetLocation) {
+	public void setMeetLocation(String meetLocation, String line, String lat, String lot) {
 		this.meetLocation = meetLocation;
+		this.line = line;
+		this.lat = lat;
+		this.lot = lot;
 	}
 }

--- a/src/main/java/com/swyp/mema/domain/meetMember/model/MeetMember.java
+++ b/src/main/java/com/swyp/mema/domain/meetMember/model/MeetMember.java
@@ -54,4 +54,8 @@ public class MeetMember extends BaseEntity {
 	public void setMeet(Meet meet) {
 		this.meet = meet;
 	}
+
+	public void setVoteLocationYn(boolean voteLocationYn) {
+		this.voteLocationYn = voteLocationYn;
+	}
 }

--- a/src/main/java/com/swyp/mema/domain/midloc/service/MidLocService.java
+++ b/src/main/java/com/swyp/mema/domain/midloc/service/MidLocService.java
@@ -1,15 +1,21 @@
 package com.swyp.mema.domain.midloc.service;
 
+import com.swyp.mema.domain.meet.exception.MeetNotFoundException;
 import com.swyp.mema.domain.meet.model.Meet;
+import com.swyp.mema.domain.meet.repository.MeetRepository;
+import com.swyp.mema.domain.meetMember.exception.MeetMemberNotFoundException;
+import com.swyp.mema.domain.meetMember.exception.NotMeetMemberException;
 import com.swyp.mema.domain.meetMember.model.MeetMember;
+import com.swyp.mema.domain.meetMember.repository.MeetMemberRepository;
 import com.swyp.mema.domain.midloc.service.structures.StationInfo;
-import com.swyp.mema.domain.station.converter.StationConverter;
 import com.swyp.mema.domain.station.dto.response.subwayInfo.SingleStationResponse;
+import com.swyp.mema.domain.user.exception.UserNotFoundException;
 import com.swyp.mema.domain.user.model.User;
+import com.swyp.mema.domain.user.repository.UserRepository;
 import com.swyp.mema.domain.voteLocation.dto.response.MidLocationResponse;
-import com.swyp.mema.domain.voteLocation.dto.response.TotalLocationResponse;
+import com.swyp.mema.domain.voteLocation.exception.LocationNotFoundException;
+import com.swyp.mema.domain.voteLocation.model.Location;
 import com.swyp.mema.domain.voteLocation.repository.LocationRepository;
-import com.swyp.mema.domain.voteLocation.service.LocationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,9 +30,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MidLocService {
 
 	private final OpenAIWorker openAIWorker;
-	private final LocationService locationService;
 	private final Stations stationService;
 	private final LocationRepository locationRepository;
+	private final MeetMemberRepository meetMemberRepository;
+	private final MeetRepository meetRepository;
+	private final UserRepository userRepository;
 
 	/**
 	 *
@@ -39,13 +47,22 @@ public class MidLocService {
 	public MidLocationResponse getMidLocation(Long meetId, Long userId) {
 
 		// 필수 검증 로직
-		User user = locationService.validateUser(userId);
-		Meet meet = locationService.validateMeet(meetId);
-		MeetMember meetMember = locationService.validateMeetMember(user, meet);
-		locationService.validateMeetMember(meetMember.getId());
+		User user = validateUser(userId);
+		Meet meet = validateMeet(meetId);
+		MeetMember meetMember = validateMeetMember(user, meet);
+
+		// 약속 ID와 약속원이 일치하는지 확인
+		if (!meetMember.getMeet().getId().equals(meetId)) {
+			throw new NotMeetMemberException();
+		}
 
 		// 유저들의 출발위치 responses
-		List<SingleStationResponse> userStartStations = locationRepository.findByMeetId(meetId).stream()
+		List<Location> locations = locationRepository.findByMeetId(meetId);
+
+		// 유저들의 출발 위치가 없는 경우 예외
+		if (locations.isEmpty()) { throw new LocationNotFoundException(); }
+
+		List<SingleStationResponse> userStartStations = locations.stream()
 			.map(location -> SingleStationResponse.builder()
 				.stationName(location.getStationName())
 				.routeName(location.getStationRoute())
@@ -55,9 +72,6 @@ public class MidLocService {
 			.toList();
 
 		SingleStationResponse midStation = getMidStation(userId, meetId);
-
-		// 미팅 중간 위치 값 저장
-		meet.setMeetLocation(midStation.getStationName());
 
 		return MidLocationResponse.builder()
 			.startStationList(userStartStations)
@@ -74,39 +88,70 @@ public class MidLocService {
 	 */
 	public SingleStationResponse getMidStation(Long userId, Long meetId) {
 
-		TotalLocationResponse reses = locationService.getTotalLocation(meetId, userId);
-		List<String> locs = reses.getStartStationList();
+		int maxRetry = 100;
+		List<String> locs = locationRepository.findByMeetId(meetId).stream()
+			.map(Location::getStationName)
+			.toList();
 
-		int peopleNum = locs.size();
-		String prompt = "우리는 지금 " + String.valueOf(peopleNum) + "명이 모이려고 해. 우리의 출발 위치는 모두 지하철 역이야. 우리는 각각 ";
-		prompt += makeString(locs);
-		prompt += "에서 출발하려고 해.";
-		prompt += " 우리 모두에게 공평한 지하철 역을 하나 찾아줘. 나는 다음과 같은 형태의 답변을 원해.다른 텍스트를 붙이지 말고 내가 원하는 형태의 답변만 적어줘.";
-		prompt += "\n추쳔역: {추천하는 역 명}, 역의 호선: {추천하는 역의 호선}\n역의 호선은 하나만 적어줘.";
-
-		String returnString = openAIWorker.callOpenAI(prompt);
-		System.out.println(prompt);
-		System.out.println(returnString);
-
-		String stationName = extractValue(returnString, "추쳔역: (.*?),");
-		String stationLine = extractValue(returnString, "역의 호선: (\\d+호선)");
-
-		//  역 이름, 호선 파싱     **괄호 지우기, 수인선, 분당선 -> 수인분당선 등등**
-		stationName = cleanStationName(stationName);
-		stationLine = cleanLine(stationLine);
-
-		String stationCode = stationLine + "_" + stationName;
-		StationInfo stationInfo = stationService.getStationInfos().get(stationCode);
-		if (stationInfo == null) {
-
-			return null;
+		if (locs.isEmpty()) {
+			throw new IllegalArgumentException("출발 위치 데이터가 없습니다.");
 		}
 
+		int peopleNum = locs.size();
+		String basePrompt = "우리는 지금 " + peopleNum + "명이 모이려고 해. 우리의 출발 위치는 모두 지하철 역이야. 우리는 각각 ";
+		basePrompt += makeString(locs);
+		basePrompt += "에서 출발하려고 해. 우리 모두에게 공평한 지하철 역을 하나 찾아줘.";
+		basePrompt += " 나는 다음과 같은 형태의 답변을 원해.다른 텍스트를 붙이지 말고 내가 원하는 형태의 답변만 적어줘.";
+		basePrompt += "\n추쳔역: {추천하는 역 명}, 역의 호선: {추천하는 역의 호선}\n역의 호선은 하나만 적어줘.";
+
+		for (int attempt = 1; attempt <= maxRetry; attempt++) {
+			try {
+				String prompt = basePrompt;
+
+				// 추가적인 시도 시 Prompt 조정
+				if (attempt > 1) {
+					prompt += " (다른 결과를 제시해줘, 이전 결과는 만족스럽지 않았어.)";
+				}
+
+				String returnString = openAIWorker.callOpenAI(prompt);
+				System.out.println(prompt);
+				System.out.println(returnString);
+
+				// OpenAI 응답 파싱
+				String stationName = extractValue(returnString, "추쳔역: (.*?),");
+				String stationLine = extractValue(returnString, "역의 호선: (\\d+호선)");
+
+				stationName = cleanStationName(stationName);
+				stationLine = cleanLine(stationLine);
+
+				String stationCode = stationLine + "_" + stationName;
+
+				StationInfo stationInfo = stationService.getStationInfos().get(stationCode);
+
+				if (stationInfo != null) {
+					return SingleStationResponse.builder()
+						.stationName(stationName)
+						.routeName(stationLine)
+						.lot(stationInfo.getLot())
+						.lat(stationInfo.getLat())
+						.build();
+				}
+
+				System.out.println("Attempt " + attempt + ": Station not found. Retrying...");
+			} catch (Exception e) {
+				// 예외 처리 및 로깅
+				System.err.println("Attempt " + attempt + ": Error during OpenAI call - " + e.getMessage());
+			}
+		}
+
+		// Fallback 값 반환
+		System.out.println("모든 시도가 실패했습니다. 기본값을 반환합니다.");
+
 		return SingleStationResponse.builder()
-			.stationName(stationName)
-			.routeName(stationLine)
-			.lot(stationInfo.getLot())
-			.lat(stationInfo.getLat())
+			.stationName("기본역")
+			.routeName("1호선")
+			.lot("0.0")
+			.lat("0.0")
 			.build();
 	}
 
@@ -168,5 +213,23 @@ public class MidLocService {
 		}
 		return cleanedLine;
 	}
+	private MeetMember validateMeetMember(User user, Meet meet) {
+		return meetMemberRepository.findByUserAndMeet(user, meet)
+			.orElseThrow(NotMeetMemberException::new);
+	}
 
+	private MeetMember validateMeetMember(Long meetMemberId) {
+		return meetMemberRepository.findById(meetMemberId)
+			.orElseThrow(MeetMemberNotFoundException::new);
+	}
+
+	private Meet validateMeet(Long meetId) {
+		return meetRepository.findById(meetId)
+			.orElseThrow(MeetNotFoundException::new);
+	}
+
+	private User validateUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(UserNotFoundException::new);
+	}
 }

--- a/src/main/java/com/swyp/mema/domain/midloc/service/Stations.java
+++ b/src/main/java/com/swyp/mema/domain/midloc/service/Stations.java
@@ -5,12 +5,12 @@ import com.swyp.mema.domain.midloc.service.structures.StationInfo;
 import com.swyp.mema.domain.midloc.service.structures.TransferStation;
 import com.swyp.mema.domain.station.dto.response.nearSubway.NearSubwayResponse;
 import com.swyp.mema.domain.station.dto.response.nearSubway.TotalNearSubwayResponse;
-import com.swyp.mema.domain.station.dto.response.subwayMaster.SubwayMasterResponse;
+import com.swyp.mema.domain.station.dto.response.subwayInfo.SingleStationResponse;
 import com.swyp.mema.domain.station.service.NearStationService;
-import com.swyp.mema.domain.station.service.StationMasterService;
+import com.swyp.mema.domain.station.service.StationService;
+
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -25,16 +25,15 @@ public class Stations {
     private final HashMap<String, StationInfo> stationInfos;   // code로 station info를 조회하는 해시맵
     private final HashMap<String, String> realTIme_lineMap;   //실시간 line -> 라인
     private final HashMap<String, String> realTime_codeMap;   //실시간 idx(StatnId) -> 역코드
-    @Autowired
-    private final StationMasterService stationLocrService;
-    @Autowired
+
+    private final StationService stationService;
     private final NearStationService nearStationService;
 
-    public Stations(StationMasterService stationLocrService, NearStationService nearStationService) {
+    public Stations(StationService stationService, NearStationService nearStationService) {
         this.stationInfos = new HashMap<>();
         this.realTIme_lineMap = new HashMap<>();
         this.realTime_codeMap = new HashMap<>();
-        this.stationLocrService = stationLocrService;
+        this.stationService = stationService;
         this.nearStationService = nearStationService;
     }
 
@@ -1695,10 +1694,10 @@ public class Stations {
      */
     public void makeStations() {
 
-        List<SubwayMasterResponse> reses = stationLocrService.getSubwayMasterByAPI().getMasterList();
-        for (SubwayMasterResponse res : reses) {
+        List<SingleStationResponse> reses = stationService.getSubwayInfo().getStationList();
 
-            String code = res.getLine() + "_" + res.getStationName();
+        for (SingleStationResponse res : reses) {
+            String code = res.getRouteName() + "_" + res.getStationName();
             StationInfo stationInfo = makeStation(res);
             this.stationInfos.put(code, stationInfo);
             stationInfo.printInfo();
@@ -1708,11 +1707,11 @@ public class Stations {
     /*
         단일 stationInfo 생성
      */
-    public StationInfo makeStation(SubwayMasterResponse res) {
+    public StationInfo makeStation(SingleStationResponse res) {
 
         StationInfo stationInfo = StationInfo.builder()
                 .stationName(res.getStationName())
-                .line(res.getLine())
+                .line(res.getRouteName())
                 .lat(res.getLat())
                 .lot(res.getLot())
                 .build();

--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -33,21 +33,18 @@ public class StationController {
 	 * 모든 지하철역 조회 API
 	 */
 	@Operation(summary = "모든 지하철역 조회 API", description = "역DB 로 모든 지하철역 정보를 조회합니다.")
-	@GetMapping("/meets/{meetId}/station/total")
+	@GetMapping("/station/total")
 	public ResponseEntity<TotalStationResponse> getAllStation(
-		@PathVariable Long meetId,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-
-		Long userId = Long.parseLong(userDetails.getUsername());
-		TotalStationResponse response = stationService.getSubwayInfo(meetId, userId);
+		TotalStationResponse response = stationService.getSubwayInfo();
 		return ResponseEntity.ok(response);
 	}
 
 	/**
 	 * 지하철 역사 마스터 API 통해 위도 & 경도를 포함한 지하철역 조회 API
 	 */
-	@Hidden
+	// @Hidden
 	@Operation(summary = "지하철 역사 마스터 API 통해 위도 & 경도 포함한 지하철역 조회 API", description = "지하철 역사 마스터 OpenAPI 로 해당 역의 위도 & 경도 값을 구합니다.",
 		security = {})
 	@GetMapping("/station/all")

--- a/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
+++ b/src/main/java/com/swyp/mema/domain/station/controller/StationController.java
@@ -44,7 +44,7 @@ public class StationController {
 	/**
 	 * 지하철 역사 마스터 API 통해 위도 & 경도를 포함한 지하철역 조회 API
 	 */
-	// @Hidden
+	@Hidden
 	@Operation(summary = "지하철 역사 마스터 API 통해 위도 & 경도 포함한 지하철역 조회 API", description = "지하철 역사 마스터 OpenAPI 로 해당 역의 위도 & 경도 값을 구합니다.",
 		security = {})
 	@GetMapping("/station/all")

--- a/src/main/java/com/swyp/mema/domain/station/service/StationService.java
+++ b/src/main/java/com/swyp/mema/domain/station/service/StationService.java
@@ -67,13 +67,7 @@ public class StationService {
 	 * Station 테이블 저장
 	 */
 	@Transactional(readOnly = true)
-	public TotalStationResponse getSubwayInfo(Long meetId, Long userId) {
-
-		// 필수 검증 로직
-		User user = validateUser(userId);
-		Meet meet = validateMeet(meetId);
-		MeetMember meetMember = validateMeetMember(user, meet);
-		validateMeetMember(meetMember.getId());
+	public TotalStationResponse getSubwayInfo() {
 
 		List<Station> all = stationRepository.findAll();
 

--- a/src/main/java/com/swyp/mema/domain/voteLocation/controller/LocationController.java
+++ b/src/main/java/com/swyp/mema/domain/voteLocation/controller/LocationController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.swyp.mema.domain.voteLocation.dto.request.CreateLocationReq;
 import com.swyp.mema.domain.voteLocation.dto.response.SingleLocationResponse;
-import com.swyp.mema.domain.voteLocation.dto.response.TotalLocationResponse;
 import com.swyp.mema.domain.voteLocation.service.LocationService;
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 
@@ -69,6 +68,7 @@ public class LocationController {
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
 		Long userId = userDetails.getUserId();
+		locationService.getTotalLocation(meetId, userId);
 		MidLocationResponse response = midLocService.getMidLocation(meetId, userId);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/swyp/mema/domain/voteLocation/exception/DuplicateVoteException.java
+++ b/src/main/java/com/swyp/mema/domain/voteLocation/exception/DuplicateVoteException.java
@@ -1,0 +1,14 @@
+package com.swyp.mema.domain.voteLocation.exception;
+
+import com.swyp.mema.global.base.exception.ErrorCode;
+import com.swyp.mema.global.base.exception.ServiceException;
+
+public class DuplicateVoteException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.DUPLICATE_LOCATION_VOTE;
+
+	public DuplicateVoteException() {
+		super(ERROR_CODE);
+	}
+
+}

--- a/src/main/java/com/swyp/mema/domain/voteLocation/exception/OnlyOneVoteException.java
+++ b/src/main/java/com/swyp/mema/domain/voteLocation/exception/OnlyOneVoteException.java
@@ -1,0 +1,13 @@
+package com.swyp.mema.domain.voteLocation.exception;
+
+import com.swyp.mema.global.base.exception.ErrorCode;
+import com.swyp.mema.global.base.exception.ServiceException;
+
+public class OnlyOneVoteException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.ONLY_ONE_LOCATION_VOTE;
+
+	public OnlyOneVoteException() {
+		super(ERROR_CODE);
+	}
+}

--- a/src/main/java/com/swyp/mema/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/mema/global/base/exception/ErrorCode.java
@@ -38,7 +38,9 @@ public enum ErrorCode {
 	VOTE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "VD006", "해당 멤버의 투표가 이미 존재합니다."),
 
 	// LOCATION VOTE
-	VOTE_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VL001", "존재하지 않는 위치 투표 ID 입니다."),
+	VOTE_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VL001", "해당 위치 투표 ID는 존재하지 않습니다."),
+	DUPLICATE_LOCATION_VOTE(HttpStatus.BAD_REQUEST, "VL002", "위치 투표는 중복해서 할 수 없습니다."),
+	ONLY_ONE_LOCATION_VOTE(HttpStatus.BAD_REQUEST, "VL003", "해당 약속의 위치 투표값이 1개라서 중간 위치를 구할 수 없습니다."),
 
 	// STATION
 	STATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "S001", "해당 역을 찾을 수 없습니다."),


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목`으로 작성해주세요. (ex) [#1] 프로젝트 초기 설정 작업 -->

### 🧑‍💻 작업 내용
- 기존 개발 디비 역 테이블에 저장되어있던 **20488건 -> 788**건으로 수정
- Chat GPT로 중간 지점 구할 때, OpenAPI 호출하던 메서드를 자체 역 DB 에서 값을 가져오도록 변경
- 중간 지점 구하는 API 호출 시점을 **'위치 투표 전체 조회' -> '위치 투표 생성'** API 변경
- 위치 투표 전체 조회 시 미팅(meet) 테이블에 저장되어 있는 **`역이름 & 호선 & 위도 & 경도`** 값 주도록 변경
- 미팅(meet) 테이블 호선 & 위도 & 경도 컬럼 추가

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #65
