### PR TITLE
[#71] @Builder @AllArgsConstructor 중복 사용으로 인한 QueryDSL 에러

### DIFF
--- a/src/main/java/com/swyp/mema/domain/meet/converter/MeetConverter.java
+++ b/src/main/java/com/swyp/mema/domain/meet/converter/MeetConverter.java
@@ -57,19 +57,16 @@ public class MeetConverter {
 			.map(
 				member -> {
 					boolean result = member.getUser().getUserId() == userId;
-					return MeetMemberRes.builder()
-						.meetMemberId(member.getId())
-						.me(result)
-						.userInfo
-							(
-								UserRes.builder()
-									.userId(member.getUser().getUserId())
-									.nickname(member.getUser().getNickname())
-									.puzzleId(member.getUser().getPuzId())
-									.puzzleColor(member.getUser().getPuzColor())
-									.build()
-							)
-						.build();
+					return new MeetMemberRes(
+						member.getId(), // meetMemberId
+						result,         // me
+						new UserRes(    // userInfo
+							member.getUser().getUserId(),   // userId
+							member.getUser().getNickname(), // nickname
+							member.getUser().getPuzId(),    // puzzleId
+							member.getUser().getPuzColor()  // puzzleColor
+						)
+					);
 				})
 			.toList();
 

--- a/src/main/java/com/swyp/mema/domain/meetMember/dto/response/MeetMemberRes.java
+++ b/src/main/java/com/swyp/mema/domain/meetMember/dto/response/MeetMemberRes.java
@@ -4,18 +4,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.swyp.mema.domain.user.dto.response.UserRes;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@NoArgsConstructor
 @JsonPropertyOrder({ "meetMemberId", "isMe", "userInfo" }) // 필드 순서 지정
 public class MeetMemberRes {
 
 	private Long meetMemberId;
 
 	@JsonProperty("isMe") // JSON에서 "isMe"로 노출
-	private boolean me;
+	private Boolean me;
 
 	private UserRes userInfo;
+
+	public MeetMemberRes(Long meetMemberId, Boolean me, UserRes userInfo) {
+		this.meetMemberId = meetMemberId;
+		this.me = me;
+		this.userInfo = userInfo;
+	}
 }

--- a/src/main/java/com/swyp/mema/domain/user/dto/response/UserRes.java
+++ b/src/main/java/com/swyp/mema/domain/user/dto/response/UserRes.java
@@ -1,15 +1,11 @@
 package com.swyp.mema.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "유저 프로필 응답")
 public class UserRes {
 
@@ -24,4 +20,11 @@ public class UserRes {
 
 	@Schema(description = "뱃지 색깔", example = "red")
 	private String puzzleColor;
+
+	public UserRes(Long userId, String nickname, Long puzzleId, String puzzleColor) {
+		this.userId = userId;
+		this.nickname = nickname;
+		this.puzzleId = puzzleId;
+		this.puzzleColor = puzzleColor;
+	}
 }

--- a/src/main/java/com/swyp/mema/domain/user/model/User.java
+++ b/src/main/java/com/swyp/mema/domain/user/model/User.java
@@ -15,7 +15,7 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long userId;
+    private Long userId;
 
     @Column(nullable = false)
     private String email;


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목`으로 작성해주세요. (ex) [#1] 프로젝트 초기 설정 작업 -->

### 🧑‍💻 작업 내용
- MeetMemberCustomRepository 에서 QueryDSL 로 `Projections.constructor` 생성자 호출
- MeetMemberRes가 @Builder 로 되어있어서 리플렉션을 통해 생성자 호출이 안됨
- 기존 @Builder 삭제 후 @AllArgsConstruct 로 호출하도록 변경

```java
@RequiredArgsConstructor
public class MeetMemberCustomRepositoryImpl implements MeetMemberCustomRepository {

	private final JPAQueryFactory queryFactory;

	@Override
	public List<MeetMemberRes> findMeetMembersWithUserInfo(Long meetId, Long userId) {

		QMeetMember qMeetMember = QMeetMember.meetMember;
		QUser qUser = QUser.user;

		return queryFactory
			.select(
				Projections.constructor(
					MeetMemberRes.class,
					qMeetMember.id, // meetMemberId
					Expressions.booleanTemplate(
						"{0} = {1}", qUser.userId, userId // isMe 계산
					), // isMe 필드
					Projections.constructor(
						UserRes.class, // 중첩된 UserRes 매핑
						qUser.userId,
						qUser.nickname,
						qUser.puzId,
						qUser.puzColor
					)
				)
			)
			.from(qMeetMember)
			.join(qUser).on(qMeetMember.user.userId.eq(qUser.userId))
			.where(qMeetMember.meet.id.eq(meetId))
			.fetch();
	}
}
```

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #70 #71 
