### PR TITLE
[#77] 비밀번호 변경, 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/swyp/mema/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/mema/domain/user/controller/UserController.java
@@ -97,4 +97,13 @@ public class UserController {
         emailAuthService.checkCode(emailCheckReq, request);
         return ResponseEntity.ok("OK");
     }
+
+    @Operation(summary = "회원 탈퇴", description = "사용자의 회원 정보를 삭제합니다.",
+            tags = "사용자", security = {})
+    @DeleteMapping("/mypage/resign")
+    public ResponseEntity<String> resign(){
+
+        userService.deleteUser();
+        return ResponseEntity.ok("OK");
+    }
 }

--- a/src/main/java/com/swyp/mema/domain/user/controller/UserController.java
+++ b/src/main/java/com/swyp/mema/domain/user/controller/UserController.java
@@ -1,17 +1,23 @@
 package com.swyp.mema.domain.user.controller;
 
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
-import com.swyp.mema.domain.user.dto.request.LoginReq;
-import com.swyp.mema.domain.user.dto.request.UpdateUserInfoReq;
+import com.swyp.mema.domain.user.dto.request.*;
 import com.swyp.mema.domain.user.dto.response.UserInfoRes;
+import com.swyp.mema.domain.user.exception.EmailNotMineException;
+import com.swyp.mema.domain.user.repository.UserRepository;
+import com.swyp.mema.domain.user.service.EmailAuthServiceCustom;
 import com.swyp.mema.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final EmailAuthServiceCustom emailAuthService;
+    private final UserRepository userRepository;
 
     @Operation(summary = "로그인 API", description = "커스텀유저의 로그인을 진행 합니다.")
     @PostMapping("/login")
@@ -48,9 +56,45 @@ public class UserController {
     @Operation(summary = "내 정보 수정 API", description = "회원 상세정보를 수정합니다.",
         tags = "사용자", security = {})
     @PatchMapping("/mypage")
-    public ResponseEntity<UserInfoRes> UpdateMyInfo(@RequestBody UpdateUserInfoReq req, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<UserInfoRes> UpdateMyInfo(@RequestBody UpdateUserInfoReq req,
+                                                    @AuthenticationPrincipal CustomUserDetails userDetails){
 
         UserInfoRes userInfoRes = userService.updateUserInfo(req,userDetails);
         return ResponseEntity.ok(userInfoRes);
+    }
+
+    @Operation(summary = "내 비밀번호 수정 API", description = "회원 비밀번호를 수정합니다.",
+        tags = "사용자", security = {})
+    @PatchMapping("/mypage/auth")
+    public ResponseEntity<String> UpdateMyPassword(@RequestBody UpdatePasswordReq req,
+                                                    @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        userService.updateUserPassword(req, userDetails);
+        return ResponseEntity.ok("OK");
+    }
+
+    @Operation(summary = "이메일 인증 코드 발송 API", description = "비밀번호 변경 시 이메일 인증 코드를 발송합니다.",
+            tags = "사용자", security = {})
+    @PostMapping("/mypage/sendEmail")
+    public ResponseEntity<String> sendEmail(@Valid @RequestBody EmailReq emailReq,
+                                            @AuthenticationPrincipal CustomUserDetails userDetails,
+                                            HttpServletRequest request,
+                                            HttpServletResponse response) {
+
+        String email = emailReq.getEmail();
+        if(!Objects.equals(userDetails.getUser().getEmail(), email)){
+            throw new EmailNotMineException();
+        }
+        emailAuthService.sendMail(email, request, response);
+        return ResponseEntity.ok("OK");
+    }
+
+    @Operation(summary = "이메일 인증 코드 검증 API", description = "비밀번호 변경 시 이메일 인증 코드를 검증합니다.",
+            tags = "사용자", security = {})
+    @PostMapping("/mypage/checkEmail")
+    public ResponseEntity<String> checkEmail(@Valid @RequestBody EmailCheckReq emailCheckReq, HttpServletRequest request) {
+
+        emailAuthService.checkCode(emailCheckReq, request);
+        return ResponseEntity.ok("OK");
     }
 }

--- a/src/main/java/com/swyp/mema/domain/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/swyp/mema/domain/user/dto/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.swyp.mema.domain.user.dto;
 
 import com.swyp.mema.domain.user.model.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -9,6 +10,7 @@ import java.util.Collection;
 
 public class CustomUserDetails implements UserDetails {
 
+    @Getter
     private final User user;
 
     public CustomUserDetails(User user) {

--- a/src/main/java/com/swyp/mema/domain/user/dto/request/UpdatePasswordReq.java
+++ b/src/main/java/com/swyp/mema/domain/user/dto/request/UpdatePasswordReq.java
@@ -1,0 +1,13 @@
+package com.swyp.mema.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "비밀번호 변경")
+public class UpdatePasswordReq {
+
+    @Schema(description = "비밀번호", example = "asdf1234")
+    private String password;
+
+}

--- a/src/main/java/com/swyp/mema/domain/user/exception/EmailAuthCodeFailException.java
+++ b/src/main/java/com/swyp/mema/domain/user/exception/EmailAuthCodeFailException.java
@@ -3,11 +3,11 @@ package com.swyp.mema.domain.user.exception;
 import com.swyp.mema.global.base.exception.ErrorCode;
 import com.swyp.mema.global.base.exception.ServiceException;
 
-public class EmailAuthSessionNotexist extends ServiceException {
+public class EmailAuthCodeFailException extends ServiceException {
 
-    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_AUTH_SESSION_NOT_EXIST;
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_AUTH_CODE_FAIL;
 
-    public EmailAuthSessionNotexist() {
+    public EmailAuthCodeFailException() {
         super(ERROR_CODE);
     }
 }

--- a/src/main/java/com/swyp/mema/domain/user/exception/EmailAuthSessionNotexistException.java
+++ b/src/main/java/com/swyp/mema/domain/user/exception/EmailAuthSessionNotexistException.java
@@ -1,0 +1,13 @@
+package com.swyp.mema.domain.user.exception;
+
+import com.swyp.mema.global.base.exception.ErrorCode;
+import com.swyp.mema.global.base.exception.ServiceException;
+
+public class EmailAuthSessionNotexistException extends ServiceException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_AUTH_SESSION_NOT_EXIST;
+
+    public EmailAuthSessionNotexistException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/swyp/mema/domain/user/exception/EmailNotMineException.java
+++ b/src/main/java/com/swyp/mema/domain/user/exception/EmailNotMineException.java
@@ -1,0 +1,13 @@
+package com.swyp.mema.domain.user.exception;
+
+import com.swyp.mema.global.base.exception.ErrorCode;
+import com.swyp.mema.global.base.exception.ServiceException;
+
+public class EmailNotMineException extends ServiceException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_NOT_MINE;
+
+    public EmailNotMineException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/swyp/mema/domain/user/exception/PasswordNotChangedException.java
+++ b/src/main/java/com/swyp/mema/domain/user/exception/PasswordNotChangedException.java
@@ -3,11 +3,11 @@ package com.swyp.mema.domain.user.exception;
 import com.swyp.mema.global.base.exception.ErrorCode;
 import com.swyp.mema.global.base.exception.ServiceException;
 
-public class EmailAuthCodeFail extends ServiceException {
+public class PasswordNotChangedException extends ServiceException {
 
-    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_AUTH_CODE_FAIL;
+    private static final ErrorCode ERROR_CODE = ErrorCode.PASSWORD_NOT_CHANGED;
 
-    public EmailAuthCodeFail() {
+    public PasswordNotChangedException() {
         super(ERROR_CODE);
     }
 }

--- a/src/main/java/com/swyp/mema/domain/user/model/User.java
+++ b/src/main/java/com/swyp/mema/domain/user/model/User.java
@@ -1,5 +1,6 @@
 package com.swyp.mema.domain.user.model;
 
+import com.swyp.mema.domain.user.exception.PasswordNotChangedException;
 import com.swyp.mema.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -41,6 +42,14 @@ public class User extends BaseEntity {
     //모임 참여 횟수
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 1")
     private Integer visitCount;
+
+    public void updatePassword(String password) {
+
+        if(this.password.equals(password)) {
+            throw new PasswordNotChangedException();
+        }
+        this.password = password;
+    }
 
     public void setUsername(String username) {
 

--- a/src/main/java/com/swyp/mema/domain/user/service/EmailAuthService.java
+++ b/src/main/java/com/swyp/mema/domain/user/service/EmailAuthService.java
@@ -1,8 +1,8 @@
 package com.swyp.mema.domain.user.service;
 
 import com.swyp.mema.domain.user.dto.request.EmailCheckReq;
-import com.swyp.mema.domain.user.exception.EmailAuthCodeFail;
-import com.swyp.mema.domain.user.exception.EmailAuthSessionNotexist;
+import com.swyp.mema.domain.user.exception.EmailAuthCodeFailException;
+import com.swyp.mema.domain.user.exception.EmailAuthSessionNotexistException;
 import com.swyp.mema.global.config.emailsender.NaverEmailConfig;
 import com.swyp.mema.global.config.env.EnvConfig;
 import jakarta.mail.Message;
@@ -84,19 +84,19 @@ public class EmailAuthService {
 //        if(session == null || session.getAttribute("code") == null){
 //
 //            // 인증제한시간 초과 혹은 잘못된 요청
-//            throw new EmailAuthSessionNotexist();
+//            throw new EmailAuthSessionNotexistException();
 //        }
         String code = session.getAttribute("mailAuth").toString();
         if(code == null){
 
             // 인증제한시간 초과 혹은 잘못된 요청
-            throw new EmailAuthSessionNotexist();
+            throw new EmailAuthSessionNotexistException();
         }
 
         if (!Objects.equals(emailCheckReq.getCode(), code)) {
 
             // 인증 코드 틀림
-            throw new EmailAuthCodeFail();
+            throw new EmailAuthCodeFailException();
         }
 
         //인증 성공

--- a/src/main/java/com/swyp/mema/domain/user/service/EmailAuthServiceCustom.java
+++ b/src/main/java/com/swyp/mema/domain/user/service/EmailAuthServiceCustom.java
@@ -1,8 +1,8 @@
 package com.swyp.mema.domain.user.service;
 
 import com.swyp.mema.domain.user.dto.request.EmailCheckReq;
-import com.swyp.mema.domain.user.exception.EmailAuthCodeFail;
-import com.swyp.mema.domain.user.exception.EmailAuthSessionNotexist;
+import com.swyp.mema.domain.user.exception.EmailAuthCodeFailException;
+import com.swyp.mema.domain.user.exception.EmailAuthSessionNotexistException;
 import com.swyp.mema.global.config.emailsender.NaverEmailConfig;
 import com.swyp.mema.global.config.env.EnvConfig;
 import jakarta.mail.Message;
@@ -11,10 +11,8 @@ import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -81,12 +79,12 @@ public class EmailAuthServiceCustom {
 
         if(customSession.get(emailCheckReq.getEmail()) == null){
 
-            throw new EmailAuthSessionNotexist();
+            throw new EmailAuthSessionNotexistException();
         }
 
         if(!Objects.equals(customSession.get(emailCheckReq.getEmail()), emailCheckReq.getCode())){
 
-            throw new EmailAuthCodeFail();
+            throw new EmailAuthCodeFailException();
         }
     }
 

--- a/src/main/java/com/swyp/mema/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/mema/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.swyp.mema.domain.user.exception.UserNotFoundException;
 import com.swyp.mema.domain.user.model.User;
 import com.swyp.mema.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +55,13 @@ public class UserService {
 
         User user = getUserById(userDetails.getUserId());
         user.updatePassword(bCryptPasswordEncoder.encode(req.getPassword()));
+    }
+
+    @Transactional
+    public void deleteUser(){
+
+        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        userRepository.deleteById(userId);
     }
 
     // 유틸리티 메서드: 값이 null이 아닐 경우 필드 업데이트

--- a/src/main/java/com/swyp/mema/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/mema/domain/user/service/UserService.java
@@ -2,12 +2,14 @@ package com.swyp.mema.domain.user.service;
 
 import com.swyp.mema.domain.user.dto.CustomUserDetails;
 import com.swyp.mema.domain.user.dto.converter.UserConverter;
+import com.swyp.mema.domain.user.dto.request.UpdatePasswordReq;
 import com.swyp.mema.domain.user.dto.request.UpdateUserInfoReq;
 import com.swyp.mema.domain.user.dto.response.UserInfoRes;
 import com.swyp.mema.domain.user.exception.UserNotFoundException;
 import com.swyp.mema.domain.user.model.User;
 import com.swyp.mema.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserConverter userConverter;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     // 사용자 조회 (예외 처리 포함)
     @Transactional(readOnly = true)
@@ -44,6 +47,13 @@ public class UserService {
         updateFieldIfNotNull(req.getPuzzleColor(), user::setPuzColor);
         updateFieldIfNotNull(req.getPuzzleId(), user::setPuzId);
         return userConverter.user2UserInfoRes(user);
+    }
+
+    @Transactional
+    public void updateUserPassword(UpdatePasswordReq req, CustomUserDetails userDetails) {
+
+        User user = getUserById(userDetails.getUserId());
+        user.updatePassword(bCryptPasswordEncoder.encode(req.getPassword()));
     }
 
     // 유틸리티 메서드: 값이 null이 아닐 경우 필드 업데이트

--- a/src/main/java/com/swyp/mema/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/mema/global/base/exception/ErrorCode.java
@@ -1,6 +1,5 @@
 package com.swyp.mema.global.base.exception;
 
-import com.swyp.mema.domain.user.exception.EmailAuthSessionNotexist;
 import org.springframework.http.HttpStatus;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -14,9 +13,11 @@ public enum ErrorCode {
 	// User
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다."),
 	USER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "U002", "사용자가 이미 등록된 약속원입니다."),
+	PASSWORD_NOT_CHANGED(HttpStatus.BAD_REQUEST, "U003", "현재와 동일한 비밀번호입니다."),
 	EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "M002", "이미 가입된 이메일입니다."),
 	EMAIL_AUTH_SESSION_NOT_EXIST(HttpStatus.BAD_REQUEST, "M003", "타임아웃 혹은 잘못된 요청입니다."),
 	EMAIL_AUTH_CODE_FAIL(HttpStatus.BAD_REQUEST, "M004", "인증 코드가 틀렸습니다."),
+	EMAIL_NOT_MINE(HttpStatus.BAD_REQUEST, "M005", "입력하신 이메일이 사용자의 이메일과 일치하지 않습니다."),
 
 	// MEET
 	MEET_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "약속이 존재하지 않습니다."),


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목`으로 작성해주세요. (ex) [#1] 프로젝트 초기 설정 작업 -->

###🧑‍💻 작업 내용
- 비밀번호 수정시 사용하는 이메일 인증 코드 발송 API, 코드 검증 API 구현 => 기존의 회원가입때 쓰던 API에는 중복가입 방지 검증이 존재
- 비밀번호 수정 API 구현
- 회원 탈퇴 API 구현

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#77 
